### PR TITLE
filepaths are synced

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,12 +64,16 @@ go-watch-logs --file-path=my.log --match='HTTP/1.1" 50' --every=60
     	full path to the log file
   -ignore string
     	regex for ignoring errors (empty to ignore none)
+  -log-level int
+    	log level (0=info, 1=debug)
   -match string
     	regex for matching errors (empty to match all lines)
   -min int
     	on minimum num of matches, it should notify (default 1)
   -ms-teams-hook string
     	ms teams webhook
+  -post string
+    	run this shell command after every scan
   -proxy string
     	http proxy for webhooks
   -version

--- a/main.go
+++ b/main.go
@@ -122,22 +122,28 @@ func watch(filePath string) {
 	// last line
 	slog.Info("Last line", "line", pkg.Truncate(result.LastLine, 50))
 
+	slog.Info("Scanning complete", "filePath", result.FilePath)
+
 	if result.ErrorCount < 0 {
 		return
 	}
 	if result.ErrorCount < f.min {
 		return
 	}
-	notify(result.ErrorCount, result.FirstLine, result.LastLine)
+	notify(result)
 }
 
-func notify(errorCount int, firstLine, lastLine string) {
+func notify(result *pkg.ScanResult) {
 	if f.msTeamsHook == "" {
 		return
 	}
 
 	slog.Info("Sending to MS Teams")
 	details := []gmt.Details{
+		{
+			Label:   "File Path",
+			Message: result.FilePath,
+		},
 		{
 			Label:   "Match Pattern",
 			Message: f.match,
@@ -152,15 +158,15 @@ func notify(errorCount int, firstLine, lastLine string) {
 		},
 		{
 			Label:   "Total Errors Found",
-			Message: fmt.Sprintf("%d", errorCount),
+			Message: fmt.Sprintf("%d", result.ErrorCount),
 		},
 		{
 			Label:   "First Line",
-			Message: firstLine,
+			Message: result.FirstLine,
 		},
 		{
 			Label:   "Last Line",
-			Message: lastLine,
+			Message: result.LastLine,
 		},
 	}
 

--- a/main.go
+++ b/main.go
@@ -6,7 +6,6 @@ import (
 	"log/slog"
 	"os"
 	"sync"
-	"time"
 
 	"github.com/jasonlvhit/gocron"
 	gmt "github.com/kevincobain2000/go-msteams/src"
@@ -19,6 +18,7 @@ type Flags struct {
 	match    string
 	ignore   string
 	dbPath   string
+	post     string
 
 	min         int
 	every       uint64
@@ -102,8 +102,9 @@ func cron() {
 
 	for _, filePath := range filePaths {
 		watch(filePath)
-		slog.Debug("Sleeping for 0.5 seconds")
-		time.Sleep(500 * time.Millisecond)
+	}
+	if f.post != "" {
+		pkg.ExecShell(f.post)
 	}
 }
 
@@ -217,6 +218,7 @@ func flags() {
 	flag.StringVar(&f.dbPath, "db-path", pkg.GetHomedir()+"/.go-watch-logs.db", "path to store db file")
 	flag.StringVar(&f.match, "match", "", "regex for matching errors (empty to match all lines)")
 	flag.StringVar(&f.ignore, "ignore", "", "regex for ignoring errors (empty to ignore none)")
+	flag.StringVar(&f.post, "post", "", "run this shell command after every scan")
 	flag.Uint64Var(&f.every, "every", 0, "run every n seconds (0 to run once)")
 	flag.IntVar(&f.logLevel, "log-level", 0, "log level (0=info, 1=debug)")
 	flag.IntVar(&f.min, "min", 1, "on minimum num of matches, it should notify")

--- a/main.go
+++ b/main.go
@@ -104,7 +104,9 @@ func cron() {
 		watch(filePath)
 	}
 	if f.post != "" {
-		pkg.ExecShell(f.post)
+		if _, err := pkg.ExecShell(f.post); err != nil {
+			slog.Error("Error running post command", "error", err.Error())
+		}
 	}
 }
 

--- a/pkg/system.go
+++ b/pkg/system.go
@@ -3,6 +3,7 @@ package pkg
 import (
 	"log/slog"
 	"os"
+	"os/exec"
 	"runtime"
 )
 
@@ -28,4 +29,10 @@ func PrintMemUsage() {
 
 func bToMb(b uint64) uint64 {
 	return b / 1024 / 1024
+}
+
+func ExecShell(command string) (string, error) {
+	cmd := exec.Command("sh", "-c", command)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
 }

--- a/pkg/watcher.go
+++ b/pkg/watcher.go
@@ -50,6 +50,7 @@ func NewWatcher(
 }
 
 type ScanResult struct {
+	FilePath   string
 	ErrorCount int
 	FirstLine  string
 	LastLine   string
@@ -129,6 +130,7 @@ func (w *Watcher) Scan() (*ScanResult, error) {
 		ErrorCount: errorCounts,
 		FirstLine:  firstLine,
 		LastLine:   lastLine,
+		FilePath:   w.filePath,
 	}, nil
 }
 


### PR DESCRIPTION
@gabriel-vasile

- (feat) process to ping healthcheck or send a daily summary
    - Added `-post=curl or shutdown` whatever in the post cmd

- For files that aren't created yet or removed
    - scan filepaths on cron. When the entire DIR is deleted then the program doesn't exit, it will keep logging as dir not found.
    - When a file is deleted, then it gets removed from the list of filepaths that it is scanning. Will log file not found for the first time tho.
    - When a file is added, then it gets added to the list of filepaths that it is scanning